### PR TITLE
Add UpdateSAMLProvider Permission to aws_iam_policy.acount policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,8 @@ resource "aws_iam_policy" "account" {
         {
             "Effect": "Allow",
             "Action": [
-                "iam:GetSAMLProvider"
+                "iam:GetSAMLProvider",
+                "iam:UpdateSAMLProvider"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
For account assignments in the same account as the SSO instance, occasionally the SAML Provider metadata will be automatically updated by AWS, so the role needs the `iam:UpdateSAMLProvider` permission